### PR TITLE
Tornar servidor configurável

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ libs/AndroidPushRefresh/bin/
 libs/AndroidPushRefresh/gen/
 libs/ViewPagerIndicator/bin/
 libs/ViewPagerIndicator/gen/
+server.properties

--- a/code/assets/server.properties.example
+++ b/code/assets/server.properties.example
@@ -1,0 +1,4 @@
+#Modelo para server.properties. Faça uma cópia deste arquivo no mesmo diretório(assets),
+#renomeie-o para server.properties, e adicione as informações corretas do servidor.
+ip_address=192.168.168.168
+port=3000

--- a/code/project.properties
+++ b/code/project.properties
@@ -11,7 +11,7 @@
 #proguard.config=${sdk.dir}/tools/proguard/proguard-android.txt:proguard-project.txt
 
 # Project target.
-target=android-16
+target=android-21
 android.library.reference.1=../libs/redu-android
 android.library.reference.2=../libs/ViewPagerIndicator
 android.library.reference.3=../libs/AndroidPushRefresh

--- a/code/res/values/strings.xml
+++ b/code/res/values/strings.xml
@@ -26,5 +26,6 @@
     <string name="new_lectures_key">new_lectures</string>
     <string name="new_lectures_title">Novas Aulas</string>
     <string name="new_lectures_summary">Novas Aulas nas Disciplinas que participo</string>
+    <string name="error_server_file">Arquivo server.properties inexistente ou incorretamente configurado.</string>
 
 </resources>

--- a/code/src/br/com/redu/redumobile/activities/HomeActivity.java
+++ b/code/src/br/com/redu/redumobile/activities/HomeActivity.java
@@ -22,6 +22,7 @@ import android.widget.AdapterView.OnItemClickListener;
 import android.widget.ArrayAdapter;
 import android.widget.ListView;
 import android.widget.PopupWindow;
+import br.com.developer.redu.http.ServerInfo;
 import br.com.redu.redumobile.R;
 import br.com.redu.redumobile.ReduApplication;
 import br.com.redu.redumobile.data.LoadStatusesFromWebTask;
@@ -110,12 +111,16 @@ public class HomeActivity extends DbHelperHolderActivity {
 				case 1:
 					i = new Intent(getApplicationContext(), WebViewActivity.class);
 					i.putExtra(WebViewActivity.EXTRAS_TITLE, "Termos de Uso");
-					i.putExtra(WebViewActivity.EXTRAS_URL, "http://www.redu.com.br/paginas/termos_uso");
+					i.putExtra(WebViewActivity.EXTRAS_URL, String.format(
+							"http://%s:%s/paginas/termos_uso",
+							ServerInfo.getIpAddress(), ServerInfo.getPort()));
 					break;
 				case 2:
 					i = new Intent(getApplicationContext(), WebViewActivity.class);
 					i.putExtra(WebViewActivity.EXTRAS_TITLE, "Política de Privacidade");
-					i.putExtra(WebViewActivity.EXTRAS_URL, "http://www.redu.com.br/paginas/politica_privacidade");
+					i.putExtra(WebViewActivity.EXTRAS_URL, String.format(
+							"http://%s:%s/paginas/politica_privacidade",
+							ServerInfo.getIpAddress(), ServerInfo.getPort()));
 					break;
 				case 3:
 					i = new Intent(getApplicationContext(), LoginWebViewActivity.class);

--- a/code/src/br/com/redu/redumobile/db/DbHelper.java
+++ b/code/src/br/com/redu/redumobile/db/DbHelper.java
@@ -11,6 +11,7 @@ import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
 import android.util.Log;
+import br.com.developer.redu.http.ServerInfo;
 import br.com.developer.redu.models.Link;
 import br.com.developer.redu.models.Status;
 import br.com.developer.redu.models.Thumbnail;
@@ -264,14 +265,17 @@ public class DbHelper extends SQLiteOpenHelper {
 		SQLiteDatabase db = this.getReadableDatabase();  
 		Cursor cursor;  
 
-		String query = "SELECT * FROM " + StatusTable.NAME + 
-				" WHERE " + StatusTable.COLUMN_CREATED_AT_IN_MILLIS + (olderThan ? "<" : ">") + timestamp + " AND " + 
-				StatusTable.COLUMN_ID + " IN " + 
-					"(SELECT " + LinkTable.COLUMN_STATUS_ID + " FROM " + LinkTable.NAME + 
-						" WHERE " + LinkTable.COLUMN_REL + " = \"" + Link.REL_SPACE + "\" AND " + 
-						LinkTable.COLUMN_HREF + " = " + "\"http://www.redu.com.br/api/spaces/" + spaceId + "\")" + 
-				" ORDER BY " + StatusTable.COLUMN_CREATED_AT_IN_MILLIS + " DESC" +
-				" LIMIT " + count; 
+		String query = "SELECT * FROM " + StatusTable.NAME + " WHERE "
+				+ StatusTable.COLUMN_CREATED_AT_IN_MILLIS
+				+ (olderThan ? "<" : ">") + timestamp + " AND "
+				+ StatusTable.COLUMN_ID + " IN " + "(SELECT "
+				+ LinkTable.COLUMN_STATUS_ID + " FROM " + LinkTable.NAME
+				+ " WHERE " + LinkTable.COLUMN_REL + " = \"" + Link.REL_SPACE
+				+ "\" AND " + LinkTable.COLUMN_HREF + " = " + "\"http://"
+				+ ServerInfo.getIpAddress() + ":" + ServerInfo.getPort()
+				+ "/api/spaces/" + spaceId + "\")" + " ORDER BY "
+				+ StatusTable.COLUMN_CREATED_AT_IN_MILLIS + " DESC" + " LIMIT "
+				+ count;
 		
 		cursor = db.rawQuery(query, null);
 		
@@ -291,15 +295,18 @@ public class DbHelper extends SQLiteOpenHelper {
 		
 		SQLiteDatabase db = this.getReadableDatabase();  
 		Cursor cursor;  
-		
-		String query = "SELECT * FROM " + StatusTable.NAME + 
-				" WHERE " + StatusTable.COLUMN_CREATED_AT_IN_MILLIS + (olderThan ? "<" : ">") + timestamp + " AND " + 
-				StatusTable.COLUMN_ID + " IN " + 
-				"(SELECT " + LinkTable.COLUMN_STATUS_ID + " FROM " + LinkTable.NAME + 
-				" WHERE " + LinkTable.COLUMN_REL + " = \"" + Link.REL_LECTURE + "\" AND " + 
-				LinkTable.COLUMN_HREF + " LIKE " + "\"http://www.redu.com.br/api/lectures/" + lectureId + "%\")" + 
-				"ORDER BY " + StatusTable.COLUMN_CREATED_AT_IN_MILLIS + " DESC " +
-				"LIMIT " + count; 
+
+		String query = "SELECT * FROM " + StatusTable.NAME + " WHERE "
+				+ StatusTable.COLUMN_CREATED_AT_IN_MILLIS
+				+ (olderThan ? "<" : ">") + timestamp + " AND "
+				+ StatusTable.COLUMN_ID + " IN " + "(SELECT "
+				+ LinkTable.COLUMN_STATUS_ID + " FROM " + LinkTable.NAME
+				+ " WHERE " + LinkTable.COLUMN_REL + " = \"" + Link.REL_LECTURE
+				+ "\" AND " + LinkTable.COLUMN_HREF + " LIKE " + "\"http://"
+				+ ServerInfo.getIpAddress() + ":" + ServerInfo.getPort()
+				+ "/api/lectures/" + lectureId + "%\")" + "ORDER BY "
+				+ StatusTable.COLUMN_CREATED_AT_IN_MILLIS + " DESC " + "LIMIT "
+				+ count;
 		
 		cursor = db.rawQuery(query, null);
 		

--- a/libs/AndroidPushRefresh/project.properties
+++ b/libs/AndroidPushRefresh/project.properties
@@ -8,5 +8,5 @@
 # project structure.
 
 # Project target.
-target=android-16
+target=android-21
 android.library=true

--- a/libs/ViewPagerIndicator/project.properties
+++ b/libs/ViewPagerIndicator/project.properties
@@ -9,4 +9,4 @@
 
 android.library=true
 # Project target.
-target=android-16
+target=android-21

--- a/libs/WebCachedImageView/code/project.properties
+++ b/libs/WebCachedImageView/code/project.properties
@@ -11,5 +11,5 @@
 #proguard.config=${sdk.dir}/tools/proguard/proguard-android.txt:proguard-project.txt
 
 # Project target.
-target=android-17
+target=android-21
 android.library=true


### PR DESCRIPTION
A intenção desta mudança é parametrizar o endereço IP e porta do servidor, tornando o seu uso configurável. A mudança é necessária já que as instâncias do aplicativo não mais apontarão para um único servidor(www.redu.com.br).

Como expliquei nesse PR ao redu-android(https://github.com/redu/redu-android/pull/3), são necessárias alterações tanto no redu mobile quanto no redu-android, seu submódulo. Este PR complementa o PR do redu-android.

A partir do arquivo modelo server.properties.example, é possível criar o arquivo server.properties, cujas informações são lidas e armazenadas pela classe ServerInfo. Esta, por sua vez, provê tais informações às outras classes interessadas. 
